### PR TITLE
chore: removed unnecessary dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,6 @@
     "semantic-release": "^4.3.5",
     "stylelint": "^6.2.2",
     "stylelint-config-strict": "^5.0.0",
-    "teaspoon": "^5.0.0",
     "travis-after-all": "^1.4.4",
     "validate-commit-msg": "^2.6.1",
     "watchify": "^3.7.0"


### PR DESCRIPTION
Looks like this isn't used anywhere and it was causing dependency issues.
https://www.npmjs.com/package/teaspoon
